### PR TITLE
Feat/optional message fields

### DIFF
--- a/src/SiwsMessage.ts
+++ b/src/SiwsMessage.ts
@@ -1,15 +1,15 @@
 import type { InjectedExtension } from "@polkadot/extension-inject/types"
 import { Address } from "./utils"
 
-export const siwsVersions: string[] = ["1.0.0"];
-export type SiwsVersion = typeof siwsVersions[number];
+export const siwsVersions: string[] = ["1.0.0"]
+export type SiwsVersion = typeof siwsVersions[number]
 
 export function isSiwsVersion(version?: string): version is SiwsVersion {
-  return siwsVersions.indexOf(version as SiwsVersion) !== -1;
+  return siwsVersions.indexOf(version as SiwsVersion) !== -1
 }
 
 export namespace Siws {
-  export const CURRENT_VERSION: SiwsVersion = "1.0.0";
+  export const CURRENT_VERSION: SiwsVersion = "1.0.0"
 }
 export class SiwsMessage {
   /**RFC 4501 dns authority that is requesting the signing. */
@@ -33,13 +33,13 @@ export class SiwsMessage {
   /**timestamp of the current time. */
   issuedAt?: number
   /**timestamp that indicates a minimum time before which the signed authentication message is not valid */
-  notBefore?: number;
+  notBefore?: number
   /**Version of this message */
-  version: SiwsVersion;
+  version: SiwsVersion
   /**Application-specific value to be included in the signed payload */
-  requestId?: string;
+  requestId?: string
   /**List of information or references to information the user wishes to have resolved as part of the authentication by the relying party; express as RFC 3986 URIs */
-  resources?: string[];
+  resources?: string[]
 
 
   constructor(
@@ -58,10 +58,10 @@ export class SiwsMessage {
     this.chainName = param.chainName
     this.expirationTime = param.expirationTime
     this.issuedAt = param.issuedAt
-    this.notBefore = param.notBefore;
+    this.notBefore = param.notBefore
     this.version = param.version || Siws.CURRENT_VERSION,
-    this.requestId = param.requestId;
-    this.resources = param.resources?.length ? [...param.resources] : undefined;
+    this.requestId = param.requestId
+    this.resources = param.resources?.length ? [...param.resources] : undefined
 
     this.validateMessage()
   }
@@ -114,7 +114,7 @@ export class SiwsMessage {
     const uriField = `URI: ${this.uri}`
     const body = [uriField]
 
-    body.push(`Version: ${this.version}`);
+    body.push(`Version: ${this.version}`)
 
     if (this.chainId) body.push(`Chain ID: ${this.chainId}`)
 
@@ -192,7 +192,7 @@ export class SiwsMessage {
     // uri is required for wallets validation and to help prevent phishing attacks
     if (!this.uri || this.uri.length === 0) throw new Error("SIWS Error: uri is required")
 
-    if (!this?.version) throw new Error("SIWS Error: version is required");
+    if (!this?.version) throw new Error("SIWS Error: version is required")
     if (!isSiwsVersion(this?.version)) throw new Error("SIWS Error: version is not a valid version")
 
     // nonce is required
@@ -223,7 +223,7 @@ export class SiwsMessage {
     }
 
     if (this.notBefore) {
-      const notBeforeTimeDate = new Date(this.notBefore);
+      const notBeforeTimeDate = new Date(this.notBefore)
       // invalid timestamp
       if (isNaN(notBeforeTimeDate.getTime()))
         throw new Error("SIWS Error: notBefore is not a valid date")

--- a/src/SiwsMessage.ts
+++ b/src/SiwsMessage.ts
@@ -1,6 +1,16 @@
 import type { InjectedExtension } from "@polkadot/extension-inject/types"
 import { Address } from "./utils"
 
+export const siwsVersions: string[] = ["1.0.0"];
+export type SiwsVersion = typeof siwsVersions[number];
+
+export function isSiwsVersion(version?: string): version is SiwsVersion {
+  return siwsVersions.indexOf(version as SiwsVersion) !== -1;
+}
+
+export namespace Siws {
+  export const CURRENT_VERSION: SiwsVersion = "1.0.0";
+}
 export class SiwsMessage {
   /**RFC 4501 dns authority that is requesting the signing. */
   domain: string
@@ -22,6 +32,15 @@ export class SiwsMessage {
   expirationTime?: number
   /**timestamp of the current time. */
   issuedAt?: number
+  /**timestamp that indicates a minimum time before which the signed authentication message is not valid */
+  notBefore?: number;
+  /**Version of this message */
+  version: SiwsVersion;
+  /**Application-specific value to be included in the signed payload */
+  requestId?: string;
+  /**List of information or references to information the user wishes to have resolved as part of the authentication by the relying party; express as RFC 3986 URIs */
+  resources?: string[];
+
 
   constructor(
     param: Omit<
@@ -39,6 +58,10 @@ export class SiwsMessage {
     this.chainName = param.chainName
     this.expirationTime = param.expirationTime
     this.issuedAt = param.issuedAt
+    this.notBefore = param.notBefore;
+    this.version = param.version || Siws.CURRENT_VERSION,
+    this.requestId = param.requestId;
+    this.resources = param.resources?.length ? [...param.resources] : undefined;
 
     this.validateMessage()
   }
@@ -57,6 +80,10 @@ export class SiwsMessage {
       chainId: this.chainId,
       issuedAt: this.issuedAt,
       expirationTime: this.expirationTime,
+      notBefore: this.notBefore,
+      version: this.version,
+      requestId: this.requestId,
+      resources: this.resources?.length ? [...this.resources] : undefined,
     }
   }
 
@@ -87,6 +114,8 @@ export class SiwsMessage {
     const uriField = `URI: ${this.uri}`
     const body = [uriField]
 
+    body.push(`Version: ${this.version}`);
+
     if (this.chainId) body.push(`Chain ID: ${this.chainId}`)
 
     body.push(`Nonce: ${this.nonce}`)
@@ -96,6 +125,17 @@ export class SiwsMessage {
 
     if (this.expirationTime)
       body.push(`Expiration Time: ${new Date(this.expirationTime).toISOString()}`)
+
+    if (this.notBefore)
+      body.push(`Not Before: ${new Date(this.notBefore).toISOString()}`)
+
+    if (this.requestId)
+      body.push(`Request ID: ${this.requestId}`)
+
+    if (this.resources?.length) {
+      body.push(`Resources:`)
+      this.resources.forEach((resource) => body.push(`- ${resource}`))
+    }
 
     message += body.join("\n")
 
@@ -152,6 +192,9 @@ export class SiwsMessage {
     // uri is required for wallets validation and to help prevent phishing attacks
     if (!this.uri || this.uri.length === 0) throw new Error("SIWS Error: uri is required")
 
+    if (!this?.version) throw new Error("SIWS Error: version is required");
+    if (!isSiwsVersion(this?.version)) throw new Error("SIWS Error: version is not a valid version")
+
     // nonce is required
     if (!this.nonce || this.nonce.length === 0) throw new Error("SIWS Error: nonce is required")
 
@@ -171,9 +214,28 @@ export class SiwsMessage {
       if (this.issuedAt && expirationTimeDate.getTime() <= new Date(this.issuedAt).getTime())
         throw new Error("SIWS Error: expirationTime must be greater than issuedAt")
 
+      if (this?.notBefore && this.expirationTime <= this.notBefore)
+        throw new Error("SIWS Error: expirationTime must be greater than notBefore")
+
       // token has expired
       if (expirationTimeDate.getTime() <= new Date().getTime())
         throw new Error("SIWS Error: message has expired!")
+    }
+
+    if (this.notBefore) {
+      const notBeforeTimeDate = new Date(this.notBefore);
+      // invalid timestamp
+      if (isNaN(notBeforeTimeDate.getTime()))
+        throw new Error("SIWS Error: notBefore is not a valid date")
+    }
+
+    if (this.requestId && !/^[^\n]*$/g.test(this.requestId))
+      throw new Error("SIWS Error: requestId must not contain newlines")
+
+    if (this.resources?.length) {
+      this.resources.forEach((resource) => {
+        if (!URL.canParse(resource)) throw new Error(`SIWS Error: resources must be valid URLs: ${resource}`)
+      })
     }
   }
 

--- a/src/parseMessage.ts
+++ b/src/parseMessage.ts
@@ -108,13 +108,13 @@ export const parseMessage = (message: string): SiwsMessage => {
     })
 
     // parse additional resources
-    const resourcesMatch = /Resources:\s*\n((?:- [^\n]*\n*)+)/g.exec(body);
+    const resourcesMatch = /Resources:\s*\n((?:- [^\n]*\n*)+)/g.exec(body)
     if (resourcesMatch?.length) {
-      resources = [];
+      resources = []
       const resourcesList = resourcesMatch[1]
-      const resourceMatches = resourcesList.matchAll(/- ([^\n]*)\n?/g);
+      const resourceMatches = resourcesList.matchAll(/- ([^\n]*)\n?/g)
       for (const resource of resourceMatches) {
-        resources.push(resource[1]);
+        resources.push(resource[1])
       }
     }
 

--- a/test/config.ts
+++ b/test/config.ts
@@ -1,3 +1,5 @@
+import { Siws } from "../src/SiwsMessage"
+
 export const VALID_ADDRESS = "5DFMVCaWNPcSdPVmK7d6g81ZV58vw5jkKbQk8vR4FSxyhJBD"
 
 export const ALICE = {
@@ -11,9 +13,17 @@ export const validParams = {
   address: VALID_ADDRESS,
   statement: "This is a test statement",
   uri: "https://siws.xyz",
+  version: Siws.CURRENT_VERSION,
   azeroId: "siws.azero",
   nonce: "1234567890",
   chainId: "polkadot",
   // expires in 30 seconds
   expirationTime: new Date().getTime() + 30_000,
+  notBefore: new Date().getTime(),
+  requestId: "client-specific request ID",
+  resources: [
+    "http://some-domain/path/to/resource",
+    "https://some-other-domain/path/to/resource?withQuery=search&otherQuery=otherSearch",
+    "wss://frequency-rpc.dwellir.com"
+  ]
 }


### PR DESCRIPTION
# Description
This PR adds support for the full message specification for a chain-agnostic sign-in message, including optional fields, as detailed in [CAIP-122](https://github.com/ChainAgnostic/CAIPs/blob/main/CAIPs/caip-122.md)

## Fields added:
* `version`: [required] Allows the message originator to specify a version of the message that the current message conforms to. This allows for backwards-compatibility if the message content evolves in the future: Default: `Siws.CURRENT_VERSION` (1.0.0)
* `notBefore`: [optional] An optional timestamp before which the signed payload will not be considered valid. Expressed as milliseconds since midnight on Jan 1, 1970
* `requestId`: [optional] A client-specific value that will be signed into the message payload; allows for client-specific data to be signed and recycled back to the originator for application-specific purposes. May be any string, but must not contain any newlines.
* `resources`: [optional] An array of URLs that the client app may want to resolve to provide additional checks or display to the end user. Must be valid [RFC 3986](https://www.rfc-editor.org/rfc/rfc3986) URIs