### PR TITLE
fix: bump minor version of @azns/resolver-core

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,15 @@
 {
   "name": "@talismn/siws",
-  "version": "0.0.13",
+  "version": "0.0.18",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@talismn/siws",
-      "version": "0.0.13",
+      "version": "0.0.18",
       "license": "MIT",
       "dependencies": {
-        "@azns/resolver-core": "^1.6.0",
+        "@azns/resolver-core": "^1.7.0",
         "@types/jest": "^29.5.8"
       },
       "devDependencies": {
@@ -54,17 +54,16 @@
       }
     },
     "node_modules/@azns/resolver-core": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/@azns/resolver-core/-/resolver-core-1.6.0.tgz",
-      "integrity": "sha512-3yhZanhezcw5FZLnFb5fPJ34xEmjWy2PtYkKsqbfHrQ8Pn3xql0c0nOqrlXn2P55FzkMvnQJTqEJ5zxzUj48Cg==",
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/@azns/resolver-core/-/resolver-core-1.7.0.tgz",
+      "integrity": "sha512-Y/ha53X/i627pTAXZ2eIJiMFzFGcbZtdWxyRsANkQia6Y9ru7GYNN4uz61N+yaN7NAPBbVc8v6rYdBge10w7BQ==",
       "dependencies": {
         "bufferutil": "^4.0.7",
         "loglevel": "^1.8.1",
         "utf-8-validate": "^6.0.3"
       },
       "engines": {
-        "node": ">=16 <=18",
-        "pnpm": "8"
+        "node": ">=18"
       },
       "peerDependencies": {
         "@polkadot/api": ">=10",
@@ -7180,9 +7179,9 @@
       }
     },
     "@azns/resolver-core": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/@azns/resolver-core/-/resolver-core-1.6.0.tgz",
-      "integrity": "sha512-3yhZanhezcw5FZLnFb5fPJ34xEmjWy2PtYkKsqbfHrQ8Pn3xql0c0nOqrlXn2P55FzkMvnQJTqEJ5zxzUj48Cg==",
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/@azns/resolver-core/-/resolver-core-1.7.0.tgz",
+      "integrity": "sha512-Y/ha53X/i627pTAXZ2eIJiMFzFGcbZtdWxyRsANkQia6Y9ru7GYNN4uz61N+yaN7NAPBbVc8v6rYdBge10w7BQ==",
       "requires": {
         "bufferutil": "^4.0.7",
         "loglevel": "^1.8.1",

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "@polkadot/extension-dapp": "^0.46.5"
   },
   "dependencies": {
-    "@azns/resolver-core": "^1.6.0",
+    "@azns/resolver-core": "^1.7.0",
     "@types/jest": "^29.5.8"
   },
   "directories": {


### PR DESCRIPTION
Bump `@azns/resolver-core` from 1.6.0 -> 1.7.0.

Should resolve an issue where consuming this package in other projects using Node.js 20.x log loud errors about `EBADENGINE` when using `npm` as the package manager. Does not appear to be a problem when using `pnpm`.