### PR TITLE
fix: peer dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,8 +30,8 @@
     "typescript": "^5.2.2"
   },
   "peerDependencies": {
-    "@polkadot/api": "^10.10.1",
-    "@polkadot/extension-dapp": "^0.46.5"
+    "@polkadot/api": "*",
+    "@polkadot/extension-dapp": "*"
   },
   "dependencies": {
     "@azns/resolver-core": "^1.6.0",


### PR DESCRIPTION
This should remove useless warnings that we get in the wallet when installing dependencies:
![image](https://github.com/user-attachments/assets/8320cb28-3c01-44e2-b9a6-31c3c330116e)


As those packages update so often, it's best not to pin specific versions.